### PR TITLE
Fixed project.json wrong compile paths

### DIFF
--- a/code/netstandard/project.json
+++ b/code/netstandard/project.json
@@ -11,11 +11,11 @@
             "NETSTANDARD15"
         ],
         "compile": [
-            "../code/*.cs",
-            "../code/DataStructures/*.cs",
-            "../code/Native/*.cs",
-            "../code/Native/Unix/*.cs",
-            "../code/Native/Windows/*.cs"
+            "../*.cs",
+            "../DataStructures/*.cs",
+            "../Native/*.cs",
+            "../Native/Unix/*.cs",
+            "../Native/Windows/*.cs"
         ],
         "outputName": "RJCP.SerialPortStream"
     },


### PR DESCRIPTION
Adding this library via NuGet to a .NET Core / .NET Standard project result in an empty assembly (without any of the project classes).

This is caused by wrong import paths in the project.json file:

`"../code/*.cs",`

Relative to the project.json path `"../code` folder does not exist.

Removed the `/code` part in the pull request.