### PR TITLE
path changes that were necessary for me to get cmake to work

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ and then run your Mono program from there.
 Or you can build and install in your system:
 
 ```
-$ cd serialportstream/
+$ cd SerialPortStream/dll/serialunix
 $ mkdir mybuild
 $ cd mybuild
 $ cmake .. && make


### PR DESCRIPTION
This slightly different step seemed to be necessary for me to get cmake to work on my raspberry pi.  BUT I don't know the first thing about cmake, so just see what you think, yourself.

Also worth noting, I had to rename ibnserial.so.1.1 to ibnserial.so.1 just like in this comment [here](https://github.com/dotnet/core/issues/740#issuecomment-314558139), but I really don't know if these instructions should ever be updated to reflect that, or if the need to rename the file might be particular only to me.