### PR TITLE
Issue 55

### DIFF
--- a/SerialPortStream-netstandard15.sln
+++ b/SerialPortStream-netstandard15.sln
@@ -3,20 +3,26 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.26430.13
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "netstandard", "code\SerialPortStream-netstandard15.csproj", "{104EE9DA-BCC0-4DB9-AA27-617544FCA2E2}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SerialPortStream-netstandard15", "code\SerialPortStream-netstandard15.csproj", "{104EE9DA-BCC0-4DB9-AA27-617544FCA2E2}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
+		Signed_Release|Any CPU = Signed_Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{104EE9DA-BCC0-4DB9-AA27-617544FCA2E2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{104EE9DA-BCC0-4DB9-AA27-617544FCA2E2}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{104EE9DA-BCC0-4DB9-AA27-617544FCA2E2}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{104EE9DA-BCC0-4DB9-AA27-617544FCA2E2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{104EE9DA-BCC0-4DB9-AA27-617544FCA2E2}.Signed_Release|Any CPU.ActiveCfg = Signed_Release|Any CPU
+		{104EE9DA-BCC0-4DB9-AA27-617544FCA2E2}.Signed_Release|Any CPU.Build.0 = Signed_Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {377CBCBE-D342-42CD-A5CE-3998AB537ECD}
 	EndGlobalSection
 EndGlobal

--- a/build.bat
+++ b/build.bat
@@ -16,7 +16,7 @@ echo ======================================================================
 echo == Building SerialPortStream for netstandard1.5
 echo ======================================================================
 dotnet restore SerialPortStream-netstandard15.sln
-dotnet build --configuration Release SerialPortStream-netstandard15.sln
+dotnet build --configuration Signed_Release SerialPortStream-netstandard15.sln
 
 echo.
 pause

--- a/code/SerialPortStream-netstandard15.csproj
+++ b/code/SerialPortStream-netstandard15.csproj
@@ -11,6 +11,13 @@
     <AssemblyName>RJCP.SerialPortStream</AssemblyName>
     <PackageId>netstandard</PackageId>
     <PackageTargetFallback>$(PackageTargetFallback);portable-net46</PackageTargetFallback>
+    <Configurations>Debug;Release;Signed_Release</Configurations>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Signed_Release|AnyCPU' ">
+    <AssemblyOriginatorKeyFile>rjcp_serialportstream.pfx</AssemblyOriginatorKeyFile>
+    <SignAssembly>true</SignAssembly>
+    <DelaySign>false</DelaySign>
   </PropertyGroup>
 
   <ItemGroup>

--- a/code/SerialPortStream.nuspec
+++ b/code/SerialPortStream.nuspec
@@ -36,9 +36,9 @@
         </dependencies>
     </metadata>
     <files>
-        <file src="..\code\bin\Release\netstandard1.5\RJCP.SerialPortStream.dll" target="lib\netstandard1.5" />
-        <file src="..\code\bin\Release\netstandard1.5\RJCP.SerialPortStream.pdb" target="lib\netstandard1.5" />
-        <file src="..\code\bin\Release\netstandard1.5\RJCP.SerialPortStream.xml" target="lib\netstandard1.5" />
+        <file src="..\code\bin\Signed_Release\netstandard1.5\RJCP.SerialPortStream.dll" target="lib\netstandard1.5" />
+        <file src="..\code\bin\Signed_Release\netstandard1.5\RJCP.SerialPortStream.pdb" target="lib\netstandard1.5" />
+        <file src="..\code\bin\Signed_Release\netstandard1.5\RJCP.SerialPortStream.xml" target="lib\netstandard1.5" />
         <file src="..\distribute\lib\net40\RJCP.SerialPortStream.dll" target="lib\net40" />
         <file src="..\distribute\lib\net40\RJCP.SerialPortStream.pdb" target="lib\net40" />
         <file src="..\distribute\lib\net40\RJCP.SerialPortStream.XML" target="lib\net40" />


### PR DESCRIPTION
This PR enables strong-name signing also for the **netstandard1.5** target, so that all target assemblies in the NuGet package have the **same** *PublicKeyToken*.

This fixes #55. I verified that locally by creating a modified package of *SerialPortStream* that contains **net40**, **net45** and **netstandard1.5** target assemblies all with the **same** public key token. Then I updated my projects with that locally-built package and my problems reported as in #55 go away.

Changes I made:
- added a new build configuration 'Signed_Release' to .NET Standard 1.5 project; so that it is consistent with the other projects
- enabled signing for that new build configuration
- modified build.bat to use the new build configuration
