### PR TITLE
Expose Win32 COMMTIMEOUTS values as platform-specific settings

### DIFF
--- a/code/ISerialPortStream.cs
+++ b/code/ISerialPortStream.cs
@@ -1,4 +1,7 @@
-﻿namespace RJCP.IO.Ports
+﻿using System.Collections;
+using System.Collections.Generic;
+
+namespace RJCP.IO.Ports
 {
     using System;
     using System.IO;
@@ -785,6 +788,20 @@
         /// The size of the buffer. This value must be greater than zero. The default size is 81920.
         /// </param>
         void CopyTo(Stream destination, int bufferSize);
+
+        /// <summary>
+        /// Returns an <see cref="IDictionary{TKey,TValue}"/> containing platform-specific settings for the serial port.
+        /// </summary>
+        /// <returns>
+        /// An <see cref="IDictionary{TKey,TValue}"/> containing platform-specific settings for the serial port.
+        /// </returns>
+        IDictionary<string, object> GetPlatformSpecificSettings();
+
+        /// <summary>
+        /// Sets the values of any supported platform-specific settings for the serial port.
+        /// </summary>
+        /// <param name="settings">An <see cref="IDictionary{TKey,TValue}"/> containing platform-specific settings for the serial port.</param>
+        void SetPlatformSpecificSettings(IDictionary<string, object> settings);
 
 #if NET45
         /// <summary>

--- a/code/ISerialPortStream.cs
+++ b/code/ISerialPortStream.cs
@@ -1,9 +1,7 @@
-﻿using System.Collections;
-using System.Collections.Generic;
-
-namespace RJCP.IO.Ports
+﻿namespace RJCP.IO.Ports
 {
     using System;
+    using System.Collections.Generic;
     using System.IO;
     using System.Text;
 #if NET45

--- a/code/Native/INativeSerial.cs
+++ b/code/Native/INativeSerial.cs
@@ -2,6 +2,8 @@
 // Sources at https://github.com/jcurl/SerialPortStream
 // Licensed under the Microsoft Public License (Ms-PL)
 
+using System.Collections.Generic;
+
 namespace RJCP.IO.Ports.Native
 {
     using System;
@@ -324,5 +326,19 @@ namespace RJCP.IO.Ports.Native
         /// Occurs when modem pin changes are detected.
         /// </summary>
         event EventHandler<SerialPinChangedEventArgs> PinChanged;
+
+        /// <summary>
+        /// Returns an <see cref="IDictionary{TKey,TValue}"/> containing platform-specific settings for the serial port.
+        /// </summary>
+        /// <returns>
+        /// An <see cref="IDictionary{TKey,TValue}"/> containing platform-specific settings for the serial port.
+        /// </returns>
+        IDictionary<string, object> GetPlatformSpecificSettings();
+
+        /// <summary>
+        /// Sets the values of any supported platform-specific settings for the serial port.
+        /// </summary>
+        /// <param name="settings">An <see cref="IDictionary{TKey,TValue}"/> containing platform-specific settings for the serial port.</param>
+        void SetPlatformSpecificSettings(IDictionary<string, object> settings);
     }
 }

--- a/code/Native/INativeSerial.cs
+++ b/code/Native/INativeSerial.cs
@@ -2,11 +2,10 @@
 // Sources at https://github.com/jcurl/SerialPortStream
 // Licensed under the Microsoft Public License (Ms-PL)
 
-using System.Collections.Generic;
-
 namespace RJCP.IO.Ports.Native
 {
     using System;
+    using System.Collections.Generic;
 
     /// <summary>
     /// Interface for accessing serial based streams.

--- a/code/Native/UnixNativeSerial.cs
+++ b/code/Native/UnixNativeSerial.cs
@@ -2,11 +2,10 @@
 // Sources at https://github.com/jcurl/SerialPortStream
 // Licensed under the Microsoft Public License (Ms-PL)
 
-using System.Collections.Generic;
-
 namespace RJCP.IO.Ports.Native
 {
     using System;
+    using System.Collections.Generic;
     using System.IO;
     using System.Threading;
     using Trace;

--- a/code/Native/UnixNativeSerial.cs
+++ b/code/Native/UnixNativeSerial.cs
@@ -2,6 +2,8 @@
 // Sources at https://github.com/jcurl/SerialPortStream
 // Licensed under the Microsoft Public License (Ms-PL)
 
+using System.Collections.Generic;
+
 namespace RJCP.IO.Ports.Native
 {
     using System;
@@ -956,6 +958,15 @@ namespace RJCP.IO.Ports.Native
         /// Occurs when modem pin changes are detected.
         /// </summary>
         public event EventHandler<SerialPinChangedEventArgs> PinChanged;
+
+        public IDictionary<string, object> GetPlatformSpecificSettings()
+        {
+	        return new Dictionary<string, object>();
+        }
+
+        public void SetPlatformSpecificSettings(IDictionary<string, object> settings)
+        {
+        }
 
         protected virtual void OnPinChanged(object sender, SerialPinChangedEventArgs args)
         {

--- a/code/Native/Windows/CommOverlappedIo.cs
+++ b/code/Native/Windows/CommOverlappedIo.cs
@@ -207,27 +207,6 @@ namespace RJCP.IO.Ports.Native.Windows
             m_Name = name;
             m_IsRunning = true;
             try {
-                // Set the time outs
-                NativeMethods.COMMTIMEOUTS timeouts = new NativeMethods.COMMTIMEOUTS() {
-                    // We read only the data that is buffered
-#if PL2303_WORKAROUNDS
-                    // Time out if data hasn't arrived in 10ms, or if the read takes longer than 100ms in total
-                    ReadIntervalTimeout = 10,
-                    ReadTotalTimeoutConstant = 100,
-                    ReadTotalTimeoutMultiplier = 0,
-#else
-                    // Non-asynchronous behaviour
-                    ReadIntervalTimeout = System.Threading.Timeout.Infinite,
-                    ReadTotalTimeoutConstant = 0,
-                    ReadTotalTimeoutMultiplier = 0,
-#endif
-                    // We have no time outs when writing
-                    WriteTotalTimeoutMultiplier = 0,
-                    WriteTotalTimeoutConstant = 500
-                };
-
-                bool result = UnsafeNativeMethods.SetCommTimeouts(m_ComPortHandle, ref timeouts);
-                if (!result) throw new IOException("Couldn't set CommTimeouts", Marshal.GetLastWin32Error());
 
                 m_Thread = new Thread(new ThreadStart(OverlappedIoThread)) {
                     Name = "SerialPortStream_" + m_Name,

--- a/code/Native/Windows/CommTimeouts.cs
+++ b/code/Native/Windows/CommTimeouts.cs
@@ -1,10 +1,10 @@
-﻿using System.Collections.Generic;
-using System.IO;
-using System.Runtime.InteropServices;
-using Microsoft.Win32.SafeHandles;
-
-namespace RJCP.IO.Ports.Native.Windows
+﻿namespace RJCP.IO.Ports.Native.Windows
 {
+	using System.Collections.Generic;
+	using System.IO;
+	using System.Runtime.InteropServices;
+	using Microsoft.Win32.SafeHandles;
+
 	internal sealed class CommTimeouts
 	{
 		private const string ReadIntervalTimeoutKey = nameof(CommTimeouts) + "." + nameof(NativeMethods.COMMTIMEOUTS.ReadIntervalTimeout);

--- a/code/Native/Windows/CommTimeouts.cs
+++ b/code/Native/Windows/CommTimeouts.cs
@@ -1,0 +1,86 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using System.Runtime.InteropServices;
+using Microsoft.Win32.SafeHandles;
+
+namespace RJCP.IO.Ports.Native.Windows
+{
+	internal sealed class CommTimeouts
+	{
+		private const string ReadIntervalTimeoutKey = nameof(CommTimeouts) + "." + nameof(NativeMethods.COMMTIMEOUTS.ReadIntervalTimeout);
+		private const string ReadTotalTimeoutConstantKey = nameof(CommTimeouts) + "." + nameof(NativeMethods.COMMTIMEOUTS.ReadTotalTimeoutConstant);
+		private const string ReadTotalTimeoutMultiplierKey = nameof(CommTimeouts) + "." + nameof(NativeMethods.COMMTIMEOUTS.ReadTotalTimeoutMultiplier);
+		private const string WriteTotalTimeoutConstantKey = nameof(CommTimeouts) + "." + nameof(NativeMethods.COMMTIMEOUTS.WriteTotalTimeoutConstant);
+		private const string WriteTotalTimeoutMultiplierKey = nameof(CommTimeouts) + "." + nameof(NativeMethods.COMMTIMEOUTS.WriteTotalTimeoutMultiplier);
+
+		private SafeFileHandle m_ComPortHandle;
+		private NativeMethods.COMMTIMEOUTS m_CommTimeouts;
+
+		public CommTimeouts(SafeFileHandle comPortHandle, IDictionary<string, object> settings)
+		{
+			m_ComPortHandle = comPortHandle;
+
+			// Set the time outs
+			m_CommTimeouts = new NativeMethods.COMMTIMEOUTS()
+			{
+				// We read only the data that is buffered
+#if PL2303_WORKAROUNDS
+                    // Time out if data hasn't arrived in 10ms, or if the read takes longer than 100ms in total
+                    ReadIntervalTimeout = 10,
+                    ReadTotalTimeoutConstant = 100,
+                    ReadTotalTimeoutMultiplier = 0,
+#else
+				// Non-asynchronous behaviour
+				ReadIntervalTimeout = System.Threading.Timeout.Infinite,
+				ReadTotalTimeoutConstant = 0,
+				ReadTotalTimeoutMultiplier = 0,
+#endif
+				// We have no time outs when writing
+				WriteTotalTimeoutMultiplier = 0,
+				WriteTotalTimeoutConstant = 500
+			};
+
+			// Update the timeouts with any user-provided values
+			SetPlatformSpecificSettings(settings);
+		}
+
+		public void GetCommTimeouts()
+		{
+			if (!UnsafeNativeMethods.GetCommTimeouts(m_ComPortHandle, ref m_CommTimeouts))
+			{
+				throw new IOException("Unable to get comm timeouts", Marshal.GetLastWin32Error());
+			}
+		}
+
+		public void SetCommTimeouts()
+		{
+			if (!UnsafeNativeMethods.SetCommTimeouts(m_ComPortHandle, ref m_CommTimeouts))
+			{
+				throw new IOException("Unable to set comm timeouts", Marshal.GetLastWin32Error());
+			}
+		}
+
+		public void GetPlatformSpecificSettings(IDictionary<string, object> settings)
+		{
+			settings[ReadIntervalTimeoutKey] = m_CommTimeouts.ReadIntervalTimeout;
+			settings[ReadTotalTimeoutConstantKey] = m_CommTimeouts.ReadTotalTimeoutConstant;
+			settings[ReadTotalTimeoutMultiplierKey] = m_CommTimeouts.ReadTotalTimeoutMultiplier;
+			settings[WriteTotalTimeoutConstantKey] = m_CommTimeouts.WriteTotalTimeoutConstant;
+			settings[WriteTotalTimeoutMultiplierKey] = m_CommTimeouts.WriteTotalTimeoutMultiplier;
+		}
+
+		public void SetPlatformSpecificSettings(IDictionary<string, object> settings)
+		{
+			UpdateInt32Setting(settings, ReadIntervalTimeoutKey, ref m_CommTimeouts.ReadIntervalTimeout);
+			UpdateInt32Setting(settings, ReadTotalTimeoutConstantKey, ref m_CommTimeouts.ReadTotalTimeoutConstant);
+			UpdateInt32Setting(settings, ReadTotalTimeoutMultiplierKey, ref m_CommTimeouts.ReadTotalTimeoutMultiplier);
+			UpdateInt32Setting(settings, WriteTotalTimeoutConstantKey, ref m_CommTimeouts.WriteTotalTimeoutConstant);
+			UpdateInt32Setting(settings, WriteTotalTimeoutMultiplierKey, ref m_CommTimeouts.WriteTotalTimeoutMultiplier);
+		}
+
+		private void UpdateInt32Setting(IDictionary<string, object> settings, string key, ref int value)
+		{
+			if (settings.TryGetValue(key, out var obj) && obj is int i) value = i;
+		}
+	}
+}

--- a/code/SerialPortStream-net40.csproj
+++ b/code/SerialPortStream-net40.csproj
@@ -81,6 +81,7 @@
     <Compile Include="Native\Windows\CommErrorEventArgs.cs" />
     <Compile Include="Native\Windows\CommEventArgs.cs" />
     <Compile Include="Native\Windows\CommOverlappedIo.cs" />
+    <Compile Include="Native\Windows\CommTimeouts.cs" />
     <Compile Include="Native\Windows\DtrControl.cs" />
     <Compile Include="Native\Windows\NativeMethods.cs" />
     <Compile Include="Native\Windows\RtsControl.cs" />

--- a/code/SerialPortStream-net45.csproj
+++ b/code/SerialPortStream-net45.csproj
@@ -81,6 +81,7 @@
     <Compile Include="Native\Windows\CommErrorEventArgs.cs" />
     <Compile Include="Native\Windows\CommEventArgs.cs" />
     <Compile Include="Native\Windows\CommOverlappedIo.cs" />
+    <Compile Include="Native\Windows\CommTimeouts.cs" />
     <Compile Include="Native\Windows\DtrControl.cs" />
     <Compile Include="Native\Windows\NativeMethods.cs" />
     <Compile Include="Native\Windows\RtsControl.cs" />

--- a/code/SerialPortStream.cs
+++ b/code/SerialPortStream.cs
@@ -7,11 +7,10 @@
 // this implementation.
 //#define DRIVERBUFFEREDBYTES
 
-using System.Collections.Generic;
-
 namespace RJCP.IO.Ports
 {
     using System;
+    using System.Collections.Generic;
     using System.Diagnostics;
     using System.Text;
     using System.IO;

--- a/code/SerialPortStream.cs
+++ b/code/SerialPortStream.cs
@@ -7,6 +7,8 @@
 // this implementation.
 //#define DRIVERBUFFEREDBYTES
 
+using System.Collections.Generic;
+
 namespace RJCP.IO.Ports
 {
     using System;
@@ -2056,6 +2058,26 @@ namespace RJCP.IO.Ports
                 TxContinueOnXOff ? "on" : "off",
                 ((Handshake & Handshake.XOn) != 0) ? "on" : "off",
                 dsrStatus, ctsStatus, dtrStatus, rtsStatus);
+        }
+
+        /// <summary>
+        /// Returns an <see cref="IDictionary{TKey,TValue}"/> containing platform-specific settings for the serial port.
+        /// </summary>
+        /// <returns>
+        /// An <see cref="IDictionary{TKey,TValue}"/> containing platform-specific settings for the serial port.
+        /// </returns>
+        public IDictionary<string, object> GetPlatformSpecificSettings()
+        {
+	        return m_NativeSerial.GetPlatformSpecificSettings();
+        }
+
+        /// <summary>
+        /// Sets the values of any supported platform-specific settings for the serial port.
+        /// </summary>
+        /// <param name="settings">An <see cref="IDictionary{TKey,TValue}"/> containing platform-specific settings for the serial port.</param>
+        public void SetPlatformSpecificSettings(IDictionary<string, object> settings)
+        {
+	        m_NativeSerial.SetPlatformSpecificSettings(settings);
         }
     }
 }


### PR DESCRIPTION
This adds a pair of methods (Get/SetPlatformSpecificSettings()) to allow the user to configure settings that are only relevant to specific platforms in a generic manner by exposing them through an `IDictionary<string,object>`.

This then fixes #74 by making the Win32 COMMTIMEOUTS values configurable via these methods.

The keys for the COMMTIMEOUTS settings are:
- `CommTimeouts.ReadIntervalTimeout`
- `CommTimeouts.ReadTotalTimeoutConstant`
- `CommTimeouts.ReadTotalTimeoutMultiplier`
- `CommTimeouts.WriteTotalTimeoutConstant`
- `CommTimeouts.WriteTotalTimeoutMultiplier`

You can configure the COMMTIMEOUTS values with the following code:

```C#
var settings = new Dictionary<string, object>();
settings["CommTimeouts.ReadIntervalTimeout"] = 100;
settings["CommTimeouts.ReadTotalTimeoutConstant"] = 0;
settings["CommTimeouts.ReadTotalTimeoutMultiplier"] = 0;
settings["CommTimeouts.WriteTotalTimeoutConstant"] = 0;
settings["CommTimeouts.WriteTotalTimeoutMultiplier"] = 0;
stream.SetPlatformSpecificSettings(settings);
```
