### PR TITLE
ReadAsync and WriteAsync implementation for .NET standard 1.5

### DIFF
--- a/code/SerialPortStream.cs
+++ b/code/SerialPortStream.cs
@@ -43,14 +43,14 @@ namespace RJCP.IO.Ports
         private SerialBuffer m_Buffer;
         private ReadToCache m_ReadTo = new ReadToCache();
 
-#region Public constants
+        #region Public constants
         /// <summary>
         /// Indicates that no time out should occur.
         /// </summary>
         public const int InfiniteTimeout = Timeout.Infinite;
-#endregion
+        #endregion
 
-#region Constructor, Port Name, Open
+        #region Constructor, Port Name, Open
         /// <summary>
         /// Constructor. Create a stream that doesn't connect to any port.
         /// </summary>
@@ -308,9 +308,9 @@ namespace RJCP.IO.Ports
                 m_NativeSerial.Close();
             }
         }
-#endregion
+        #endregion
 
-#region Computer Configuration and Ports
+        #region Computer Configuration and Ports
         /// <summary>
         /// Gets an array of serial port names for the current computer.
         /// </summary>
@@ -341,9 +341,9 @@ namespace RJCP.IO.Ports
                 return serial.GetPortDescriptions();
             }
         }
-#endregion
+        #endregion
 
-#region Reading and Writing Configuration
+        #region Reading and Writing Configuration
         /// <summary>
         /// Gets or sets the byte encoding for pre- and post-transmission conversion of text.
         /// </summary>
@@ -383,9 +383,9 @@ namespace RJCP.IO.Ports
                 m_NewLine = value;
             }
         }
-#endregion
+        #endregion
 
-#region Driver Settings
+        #region Driver Settings
         /// <summary>
         /// Specify the driver In Queue at the time it is opened.
         /// </summary>
@@ -427,7 +427,7 @@ namespace RJCP.IO.Ports
                 m_NativeSerial.DriverOutQueue = value;
             }
         }
-#endregion
+        #endregion
 
         /// <summary>
         /// Gets a value that determines whether the current stream can time out.
@@ -435,7 +435,7 @@ namespace RJCP.IO.Ports
         /// <returns>A value that determines whether the current stream can time out.</returns>
         public override bool CanTimeout { get { return true; } }
 
-#region Reading
+        #region Reading
         /// <summary>
         /// Check if this stream supports reading.
         /// </summary>
@@ -987,9 +987,9 @@ namespace RJCP.IO.Ports
                 if (m_NativeSerial.IsOpen) m_NativeSerial.DiscardInBuffer();
             }
         }
-#endregion
+        #endregion
 
-#region Writing
+        #region Writing
         /// <summary>
         /// Check if this stream supports writing.
         /// </summary>
@@ -1393,9 +1393,9 @@ namespace RJCP.IO.Ports
             // to purge.
             if (m_NativeSerial.IsOpen) m_NativeSerial.DiscardOutBuffer();
         }
-#endregion
+        #endregion
 
-#region Modem Information and Serial State
+        #region Modem Information and Serial State
         /// <summary>
         /// Gets the state of the Carrier Detect line for the port.
         /// </summary>
@@ -1464,9 +1464,9 @@ namespace RJCP.IO.Ports
                 return m_NativeSerial.RingHolding;
             }
         }
-#endregion
+        #endregion
 
-#region Serial Configuration Settings
+        #region Serial Configuration Settings
         /// <summary>
         /// Gets or sets the serial baud rate.
         /// </summary>
@@ -1796,9 +1796,9 @@ namespace RJCP.IO.Ports
                 m_NativeSerial.BreakState = value;
             }
         }
-#endregion
+        #endregion
 
-#region Seeking
+        #region Seeking
         /// <summary>
         /// This stream is not seekable, so always returns false.
         /// </summary>
@@ -1847,9 +1847,9 @@ namespace RJCP.IO.Ports
         {
             throw new NotSupportedException();
         }
-#endregion
+        #endregion
 
-#region Event Handling and Abstraction
+        #region Event Handling and Abstraction
         private readonly object m_EventLock = new object();
         private ManualResetEvent m_EventProcessing = new ManualResetEvent(false);
         private SerialData m_SerialDataFlags = SerialData.NoData;
@@ -2020,7 +2020,7 @@ namespace RJCP.IO.Ports
                 m_EventProcessing.Reset();
             }
         }
-#endregion
+        #endregion
 
         private volatile bool m_IsDisposed;
 


### PR DESCRIPTION
Hi!

This PR resolves the issue described in #114. As discussed there, .NET standard doesn't support the `Begin|EndRead` and `Begin|EndWrite` methods and the current implementation of SerialPortStream didn't implement the `ReadAsync` and `WriteAsync` methods from the `Stream` base class.

With this PR, the two methods are now implemented. The two new methods simply delegate to the existing `BeginRead` and `BeginWrite` methods using the `Task.FromAsync` method. Since `AsyncResult` isn't available any more too, we can use a `Task` instead as described [here](https://stackoverflow.com/a/55516918/1384848) (`Task` implements `IAsyncResult`).

With the approach of re-using the existing `Begin|EndRead` and `Begin|EndWrite` methods we can leverage the well tested and established code without introducing much more code to maintain.

Unfortunately, the Asynchronous Programming Model (APM) (using `Begin|EndRead` and `Begin|EndWrite` methods) didn't consider cancellation, so we cannot support the `CancallationToken` with the new `ReadAsync` and `WriteAsync` methods easily. The passsed `cancellationToken` will simply be ignored. We hope that's OK for now. Otherwise we would need to rewrite the entire read/write process using "real" asynchronicity and with "real" cancellation behavior. Since this would mean a lot more effort and more further code to maintain in future for little use, we think it's better to ignore the cancellation behavior in that case.

Regarding testing: We haven't added any more unit tests to your solution, since we saw that no .NET standard 1.5 tests were present. For testing our changes locally, we added my unit test from [my test project](https://github.com/meinsiedler/SerialPortStreamTest/blob/main/SerialPortStreamTest.Tests/SerialPortStreamTest.cs) directly, but didn't commit it to your repo. The tests now succeed with .NET Core 3.1 too.

We'd be very happy if our PR for fixing the issues with .NET Core lands in a new NuGet version of your project.

Best regards.